### PR TITLE
Reimplemented Card/Column Add and Edit Functions

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -15,9 +15,10 @@ export default class card extends Component {
         isDragDisabled: PropTypes.bool,
         disableInteractiveElementBlocking: PropTypes.bool,
         shouldRespectForcePress: PropTypes.bool,
+        editCard: PropTypes.func,
     }
 
-    onDoubleClick = e => {
+    makeCardEditable = e => {
         if (e.target.firstElementChild) {
             e.target.firstElementChild.contentEditable = true;
         } else {
@@ -25,12 +26,16 @@ export default class card extends Component {
         }
     }
 
-    onBlur = e => {
+    editCard = e => {
         e.target.contentEditable = false;
 
-        const newVal = e.target.innerText;
-        this.props.card.content = newVal;
+        const newContent = e.target.innerText;
+        const newCard = {
+            ...this.props.card,
+            content: newContent
+        }
 
+        this.props.editCard(newCard);
     }
 
     render() {
@@ -59,8 +64,8 @@ export default class card extends Component {
                         className={`card ${this.props.cardClassName}`}
                         ref={provided.innerRef}
                         isdragging={snapshot.isDragging.toString()}// TODO:
-                        onDoubleClick={this.onDoubleClick}
-                        onBlur={this.onBlur}
+                        onDoubleClick={this.makeCardEditable}
+                        onBlur={this.editCard}
                     >
                         {/* { this.props.card.content } */}
                         {this.props.renderer(this.props.card)}

--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -6,7 +6,7 @@ import Card from './Card';
 import '../css/column.css';
 
 export default class Column extends Component {
-
+        
     static propTypes = {
         headingClassName: PropTypes.string,
         cardListClassName: PropTypes.string,
@@ -14,54 +14,26 @@ export default class Column extends Component {
         onDragStyle: PropTypes.object,
         isDropDisabled: PropTypes.bool,
         isCombineEnabled: PropTypes.bool,
+        editCard: PropTypes.func,
     }
 
-    onDoubleClick = e => {
+    makeColumnEditable = e => {
         e.target.contentEditable = true;
     }
 
-    onBlur = e => {
+    editColumn = e => {
         e.target.contentEditable = false;
 
-        const newVal = e.target.innerText;
-        this.props.column.title = newVal;
-    }
-
-    // onCardDoubleClick = e => {
-    //     if (e.target.firstElementChild) {
-    //         e.target.firstElementChild.contentEditable = true;
-    //     } else {
-    //         e.target.contentEditable = true;
-    //     }
-    // }
-
-    // onCardBlur = e => {
-    //     e.target.contentEditable = false;
-
-    //     const newVal = e.target.innerText;
-    //     // this.props.card.content = newVal;
-    //     console.log(this.props)
-
-    // }
-
-    addCard = () => {
-        /*
-        console.log(this.props);
-        debugger;
-        
-
-        const newCard = {
-            id: `task-${this.props.cards.length + 1}`,
-            content: '',
+        const newTitle = e.target.innerText;
+        const newColumn = {
+            ...this.props.column,
+            title: newTitle,
         }
 
-        this.props.cards.push(newCard);
-        this.props.column.cardIds.push(newCard.id);
+        this.props.editColumn(newColumn);
+    }
 
-
-        this.forceUpdate()
-        */
-
+    addCard = () => {
         const columnId = this.props.column.id;
         this.props.addCard(columnId);
     }
@@ -71,8 +43,8 @@ export default class Column extends Component {
             <div className={`column ${this.props.columnClassName}`} >
                 <h3
                     className={`title ${this.props.columnClassName}`}
-                    onDoubleClick={this.onDoubleClick}
-                    onBlur={this.onBlur}
+                    onDoubleClick={this.makeColumnEditable}
+                    onBlur={this.editColumn}
                 >
                     {this.props.column.title}
                 </h3>
@@ -107,6 +79,7 @@ export default class Column extends Component {
                                                                             onDoubleClick={this.onCardDoubleClick} 
                                                                             onBlur={this.onCardBlur}
                                                                             renderer={this.props.renderer} 
+                                                                            editCard={this.props.editCard}
                                                                         />)}
                                 {provided.placeholder}
                             </div>)

--- a/src/components/Kanban.jsx
+++ b/src/components/Kanban.jsx
@@ -133,17 +133,37 @@ export default class Kanban extends React.Component {
     }
 
     addColumn = () => {
-        console.log(this.state)
         const newColumn = {
             id: `column-${this.state.columnOrder.length + 1}`,
             title: 'New Column',
             cardIds: [],
-        }
+        }        
 
         const newState = this.state;
 
         newState.columns[newColumn.id] = newColumn;
         newState.columnOrder.push(newColumn.id);
+
+        this.setState(newState);
+    }
+
+    editCard = (editedCard) => {
+        let cardIndex;
+        const newState = this.state;
+
+        this.state.cards.map((card, index) => {
+            if (card.id === editedCard.id) {
+                cardIndex = index;
+            }
+        })
+
+        newState.cards[cardIndex] = editedCard;
+        this.setState(newState);
+    }
+
+    editColumn = (editedColumn) => {
+        const newState = this.state;
+        newState.columns[editedColumn.id] = editedColumn;
 
         this.setState(newState);
     }
@@ -168,7 +188,14 @@ export default class Kanban extends React.Component {
                                 return this.state.cards.find(card => card["id"] === cardId)
                             })
 
-                            return <Column key={column.id} column={column} cards={cards} addCard={this.addCard} renderer={column.renderer || DefaultCardContent} />
+                            return <Column 
+                                    key={column.id} 
+                                    column={column} 
+                                    cards={cards} 
+                                    addCard={this.addCard} 
+                                    editCard={this.editCard} 
+                                    editColumn={this.editColumn} 
+                                    renderer={column.renderer || DefaultCardContent} />
                             /**
                              * @props   # key: to keep track of the columns created
                              *          # column: to pass column data

--- a/src/css/column.css
+++ b/src/css/column.css
@@ -18,7 +18,10 @@
     flex-grow: 1;
     min-height: 100px;
     max-height: 300px;
+    min-width: 200px;
+    max-width: 500px;
     overflow-y: scroll;
+    overflow-x: a;
 }
 
 


### PR DESCRIPTION
Now there is no prop changes inside the child components, all changes happen in Kanban component as a state change.

Added editCard, editColumn, addCard and addColumn functions to Kanban component.  addColumn is called inside the Kanban component, rest is passed as props to Column component.

addCard method is implemented inside the Colum component. addCard method from props is called inside the Column component's addCard method with columnId of the column which to be added a new card.

editColumn method is implemented inside the Column component. editColumn medhod from props is called inside the Column component's editColumn method with new edited colum object as an argument. editCard is passed as a prop to Card component.

editCard method is implementediside the Card component. editCard method from props is called inside the Card component's editCard method with new edited card object as an argument.

Method name changes:
* Column
** onDoubleClick ==> makeColumnEditable
** onBlur ==> editColumn
* Card
** onDoubleClick ==> makeCardEditable
** onBlur ==> editCard