### PR TITLE
Moved state out of the Kanban and Implemented DefaultRenderer compoennt

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -4,11 +4,152 @@ import Kanban from './Kanban'
 import { initialData } from '../initialData.js';
 
 export default class App extends Component {
+    state = initialData;
 
+    onDragStart = start => {
+
+        if (this.state.onDragStart) {
+            this.state.onDragStart();
+        }
+    }
+
+    onBeforeDragStart = update => {
+        // Do something..
+    }
+
+    onDragUpdate = update => {
+
+        if (this.state.onDragUpdate) {
+            this.state.onDragUpdate();
+        }
+    }
+
+    onDragEnd = result => {
+
+        const { destination, source, draggableId } = result;
+
+        if (!destination) return;
+
+        if (destination.droppableId === source.droppableId && destination.index === source.index) return;
+
+        const start = this.state.columns[source.droppableId];
+        const finish = this.state.columns[destination.droppableId];
+
+        if (start === finish) {
+            const newCardIds = Array.from(start.cardIds);
+            newCardIds.splice(source.index, 1);
+            newCardIds.splice(destination.index, 0, draggableId);
+
+            const newColumn = {
+                ...start,
+                cardIds: newCardIds,
+            };
+
+            const newState = {
+                columns: {
+                    ...this.state.columns,
+                    [newColumn.id]: newColumn
+                }
+            };
+
+            this.setState(newState);
+            return;
+        }
+
+        const startCardIds = Array.from(start.cardIds);
+        startCardIds.splice(source.index, 1);
+        const newStart = {
+            ...start,
+            cardIds: startCardIds,
+        }
+
+        const finishCardIds = Array.from(finish.cardIds);
+        finishCardIds.splice(destination.index, 0, draggableId);
+
+        const newFinish = {
+            ...finish,
+            cardIds: finishCardIds,
+        }
+
+        const newState = {
+            columns: {
+                ...this.state.columns,
+                [newStart.id]: newStart,
+                [newFinish.id]: newFinish,
+            }
+        }
+
+        this.setState(newState);
+
+
+        if (this.state.onDragEnd) {
+            this.state.onDragEnd();
+        }
+
+        return;
+    }
+
+    addCard = (columnId) => {
+        const newCard = {
+            id: `task-${this.state.cards.length + 1}`,
+            content: 'New Card',
+        }
+
+        this.state.cards.push(newCard);
+        this.state.columns[columnId].cardIds.push(newCard.id);
+
+        this.setState(this.state);
+    }
+
+    addColumn = () => {
+        const newColumn = {
+            id: `column-${this.state.columnOrder.length + 1}`,
+            title: 'New Column',
+            cardIds: [],
+        }
+
+        const newState = this.state;
+
+        newState.columns[newColumn.id] = newColumn;
+        newState.columnOrder.push(newColumn.id);
+
+        this.setState(newState);
+    }
+
+    editCard = (editedCard) => {
+        let cardIndex;
+        const newState = this.state;
+
+        this.state.cards.map((card, index) => {
+            if (card.id === editedCard.id) {
+                cardIndex = index;
+            }
+        })
+
+        newState.cards[cardIndex] = editedCard;
+        this.setState(newState);
+    }
+
+    editColumn = (editedColumn) => {
+        const newState = this.state;
+        newState.columns[editedColumn.id] = editedColumn;
+
+        this.setState(newState);
+    }
 
     render() {
         return (
-            <Kanban data={initialData}></Kanban>
+            <Kanban 
+                data={ this.state } 
+                addCard={ this.addCard } 
+                addColumn={ this.addColumn } 
+                editCard={ this.editCard } 
+                editColumn={ this.editColumn }
+                onDragStart={ this.onDragStart }
+                onDragUpdate={ this.onDragUpdate }
+                onDragEnd={ this.onDragEnd }
+                onBeforeDragStart={this.onBeforeDragStart }
+            ></Kanban>
         )
     }
 }

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -2,30 +2,12 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Draggable } from 'react-beautiful-dnd';
 
+import DefaultRenderer from './DefaultRenderer';
+
 import "../css/card.css"
 
 // Since it does not holds state, we might turn it into a stateless function component
 export default class card extends Component {
-    makeCardEditable = e => {
-        if (e.target.firstElementChild) {
-            e.target.firstElementChild.contentEditable = true;
-        } else {
-            e.target.contentEditable = true;
-        }
-    }
-
-    editCard = e => {
-        e.target.contentEditable = false;
-
-        const newContent = e.target.innerText;
-        const newCard = {
-            ...this.props.card,
-            content: newContent
-        }
-
-        this.props.editCard(newCard);
-    }
-
     render() {
         return (
             <Draggable
@@ -51,11 +33,14 @@ export default class card extends Component {
                         className={`card ${this.props.cardClassName}`}
                         ref={provided.innerRef}
                         isdragging={snapshot.isDragging.toString()}// TODO:
-                        onDoubleClick={this.makeCardEditable}
-                        onBlur={this.editCard}
                     >
-                        {/* { this.props.card.content } */}
-                        {this.props.renderer(this.props.card)}
+                        {this.props.renderer(this.props.card.id, this.props.card.content, this.props.editCard, this.props.index)}
+                        {/* <DefaultRenderer 
+                            id={this.props.card.id}
+                            content={this.props.card.content}
+                            editCard={this.props.editCard}
+                            index={ this.props.index }
+                            ></DefaultRenderer> */}
                     </div>)
                 }}
             </Draggable>

--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -12,6 +12,10 @@ export default class Column extends Component {
     }
 
     editColumn = e => {
+        if(e.keyCode !== 13) {
+            return;
+        }
+
         e.target.contentEditable = false;
 
         const newTitle = e.target.innerText;
@@ -35,8 +39,9 @@ export default class Column extends Component {
                     className={`title ${this.props.columnClassName}`}
                     onDoubleClick={this.makeColumnEditable}
                     onBlur={this.editColumn}
+                    onKeyUp={ this.editColumn }
                 >
-                    {this.props.column.title.toUpperCase()}
+                    {this.props.column.title}
                 </h3>
                 <Droppable
                     droppableId={this.props.column.id}
@@ -73,7 +78,7 @@ export default class Column extends Component {
                             </div>)
                     }}
                 </Droppable>
-                <button class="btn__add-card" type="button" onClick={ this.addCard }>Add Card</button>
+                <button className="btn__add-card" type="button" onClick={ this.addCard }>Add Card</button>
             </div>
         )
     }

--- a/src/components/DefaultRenderer.jsx
+++ b/src/components/DefaultRenderer.jsx
@@ -1,0 +1,67 @@
+import React, { Component } from 'react'
+
+/*
+export default class DefaultRenderer extends Component {
+    makeCardEditable = e => {
+        document.getElementById(`content-${ this.props.index }`).contentEditable = true;
+    }
+
+    editCard = e => {
+        // TODO: Save when hit enter
+        if(e.keyCode === 13 || e.type === 'blur') {
+            document.getElementById(`content-${this.props.index}`).contentEditable = false;
+
+            const newContent = document.getElementById(`content-${this.props.index}`).innerText;
+            const newCard = {
+                id: this.props.id,
+                content: newContent
+            }
+            this.props.editCard(newCard);
+        } 
+        return;
+    }
+
+    render() {
+        return (
+            <div id={`content-${this.props.index}`}
+                onDoubleClick={ this.makeCardEditable }
+                onBlur={ this.editCard }
+                onKeyDown={ this.editCard }
+                >
+                { this.props.content }
+            </div>
+        )
+    }
+}
+*/
+
+
+const makeCardEditable = (id) => {
+    document.getElementById(`content-${id}`).contentEditable = true;
+}
+
+const editCard = (id, editCardState, e) => {
+    if (e.keyCode === 13 || e.type === 'blur') {
+        document.getElementById(`content-${id}`).contentEditable = false;
+
+        const newContent = document.getElementById(`content-${id}`).innerText;
+        const newCard = {
+            id: id,
+            content: newContent
+        }
+        editCardState(newCard);
+    }
+    return;
+}
+
+export const DefaultRenderer = (id, content, editCardState, index) => {
+    return(
+        <div id={`content-${id}`}
+            onDoubleClick={() => {makeCardEditable(id)}}
+            onBlur={e => { editCard(id, editCardState, e) }}
+            onKeyDown={e => { editCard(id, editCardState, e) }}
+        >
+            {content}
+        </div>
+    )
+}

--- a/src/components/Kanban.jsx
+++ b/src/components/Kanban.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'prop-types';
 
+import { DefaultRenderer } from './DefaultRenderer';
 import Column from './Column';
 import '../css/index.css';
-
-const DefaultCardContent = (props) => <div>{props.content}</div>;
 export default class Kanban extends React.Component {
-    state = this.props.data;
-
     // static propTypes = {
     //     // DragDropContext container
     //     onDragStart: PropTypes.func,
@@ -39,163 +36,33 @@ export default class Kanban extends React.Component {
     //     })
     // };
 
-    onDragStart = start => {
-
-        if (this.props.onDragStart) {
-            this.props.onDragStart();
-        }
-    }
-
-    onDragUpdate = update => {
-
-        if (this.props.odDragUpdat) {
-            this.props.onDragUpdate();
-        }
-    }
-
-    onDragEnd = result => {
-
-        const { destination, source, draggableId } = result;
-
-        if (!destination) return;
-
-        if (destination.droppableId === source.droppableId && destination.index === source.index) return;
-
-        const start = this.state.columns[source.droppableId];
-        const finish = this.state.columns[destination.droppableId];
-
-        if (start === finish) {
-            const newCardIds = Array.from(start.cardIds);
-            newCardIds.splice(source.index, 1);
-            newCardIds.splice(destination.index, 0, draggableId);
-
-            const newColumn = {
-                ...start,
-                cardIds: newCardIds,
-            };
-
-            const newState = {
-                ...this.state,
-                columns: {
-                    ...this.state.columns,
-                    [newColumn.id]: newColumn
-                }
-            };
-
-            this.setState(newState);
-            return;
-        }
-
-        const startCardIds = Array.from(start.cardIds);
-        startCardIds.splice(source.index, 1);
-        const newStart = {
-            ...start,
-            cardIds: startCardIds,
-        }
-
-        const finishCardIds = Array.from(finish.cardIds);
-        finishCardIds.splice(destination.index, 0, draggableId);
-
-        const newFinish = {
-            ...finish,
-            cardIds: finishCardIds,
-        }
-
-        const newState = {
-            ...this.state,
-            columns: {
-                ...this.state.columns,
-                [newStart.id]: newStart,
-                [newFinish.id]: newFinish,
-            }
-        }
-
-        this.setState(newState);
-
-
-        if (this.props.onDragEnd) {
-            this.props.onDragEnd();
-        }
-
-        return;
-    }
-
-    addCard = (columnId) => {
-        const newCard = {
-            id: `task-${this.state.cards.length + 1}`,
-            content: 'New Card',
-        }
-
-        this.state.cards.push(newCard);
-        this.state.columns[columnId].cardIds.push(newCard.id);
-
-        this.setState(this.state);
-    }
-
-    addColumn = () => {
-        const newColumn = {
-            id: `column-${this.state.columnOrder.length + 1}`,
-            title: 'New Column',
-            cardIds: [],
-        }        
-
-        const newState = this.state;
-
-        newState.columns[newColumn.id] = newColumn;
-        newState.columnOrder.push(newColumn.id);
-
-        this.setState(newState);
-    }
-
-    editCard = (editedCard) => {
-        let cardIndex;
-        const newState = this.state;
-
-        this.state.cards.map((card, index) => {
-            if (card.id === editedCard.id) {
-                cardIndex = index;
-            }
-        })
-
-        newState.cards[cardIndex] = editedCard;
-        this.setState(newState);
-    }
-
-    editColumn = (editedColumn) => {
-        const newState = this.state;
-        newState.columns[editedColumn.id] = editedColumn;
-
-        this.setState(newState);
-    }
-
-
     render() {
         return (
             <div id="board">
                 <DragDropContext
-                    onDragStart={this.onDragStart}
-                    onDragUpdate={this.onDragUpdate}
-                    onDragEnd={this.onDragEnd}
-                    onBeforeDragStart={this.onBeforeDragStart}
+                    onDragStart={this.props.onDragStart}
+                    onDragUpdate={this.props.onDragUpdate}
+                    onDragEnd={this.props.onDragEnd}
+                    onBeforeDragStart={this.props.onBeforeDragStart}
 
                     className={this.props.className}
                 >
                     <div className={`container__columns ${this.props.columnContianerClass}`}>
-                        {this.state.columnOrder.map(columnId => {
-                            const column = this.state.columns[columnId];
+                        {this.props.data.columnOrder.map(columnId => {
+                            const column = this.props.data.columns[columnId];
 
                             const cards = column.cardIds.map(cardId => {
-                                return this.state.cards.find(card => card["id"] === cardId)
+                                return this.props.data.cards.find(card => card["id"] === cardId)
                             })
 
                             return <Column 
                                     key={column.id} 
                                     column={column} 
                                     cards={cards} 
-                                    addCard={this.addCard} 
-                                    editCard={this.editCard} 
-                                    editColumn={this.editColumn} 
-                                    renderer={column.renderer || DefaultCardContent} />
+                                    addCard={this.props.addCard} 
+                                    editCard={this.props.editCard} 
+                                    editColumn={this.props.editColumn} 
+                                    renderer={this.props.renderer ? this.props.renderer : DefaultRenderer} />
                             /**
                              * @props   # key: to keep track of the columns created
                              *          # column: to pass column data
@@ -204,7 +71,7 @@ export default class Kanban extends React.Component {
                         })}
                     </div>
                 </DragDropContext>
-                <button id="btn__add-column"  type="button" onClick={this.addColumn}>Add Column</button>
+                <button id="btn__add-column" type="button" onClick={this.props.addColumn}>Add Column</button>
             </div>
         )
     }

--- a/src/css/column.css
+++ b/src/css/column.css
@@ -9,6 +9,7 @@
 }
 
 .title {
+    text-transform: uppercase;
     font-size: 20px;
     font-weight: bold;
     padding: 8px;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -15,6 +15,7 @@ code {
 
 
 #board {
+    padding: 2%;
     display: flex;
 }
 
@@ -23,5 +24,11 @@ code {
 }
 
 #btn__add-column {
-    
+    max-width: 100px;
+    padding: 10px;
+    margin-left: 2%;
+    border-radius: 5px;
+    background: lightblue;
+    font-size: 16px;
+    font-weight: bold;
 }


### PR DESCRIPTION
State in the kanban component which we set from props data from App component is now removed. All state change methods are now inside the App component.

A stateless DefaultRenderer is defined. Now card component does not handles onDoubleClick, blur or buttonDown operations. All done within renderer component given by the developer. If not given, DefaultRenderer is used.